### PR TITLE
chore(pom.xml,Jenkinsfile) ensure artifact caching proxy is used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(tests: [skip: true],useArtifactCachingProxy: false, spotbugs: [qualityGates: [[threshold: 1000, type: 'TOTAL', unstable: false]] ])
+buildPlugin(tests: [skip: true],useArtifactCachingProxy: true, useContainerAgent: true, spotbugs: [qualityGates: [[threshold: 1000, type: 'TOTAL', unstable: false]] ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(tests: [skip: true],useArtifactCachingProxy: true, useContainerAgent: true, spotbugs: [qualityGates: [[threshold: 1000, type: 'TOTAL', unstable: false]] ])
+buildPlugin(tests: [skip: true], useContainerAgent: true, spotbugs: [qualityGates: [[threshold: 1000, type: 'TOTAL', unstable: false]] ])

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
 	<repository>
-    	<id>in-project</id>
-    	<name>In Project Repo</name>
+    	<id>local</id>
+    	<name>Local Repository (artefact in project source code)</name>
     	<url>file://${project.basedir}/lib</url>
 	</repository>
   </repositories>


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3567, this PR introduces the following changes to fix the build:

- `pom.xml`: Change the identifier of the maven repository pointing to the local JAR artefacts to `local` to ensure it's excluded from the artifact caching proxy
- `Jenkinsfile`:
    - Enable the Artifact Caching Proxy but keep it explicit
    - Ensure that container agent are used (cheaper and faster but does not provide `docker`)

